### PR TITLE
Fix bytearray TypeError Issue For Non-Express Boards

### DIFF
--- a/adafruit_trellis.py
+++ b/adafruit_trellis.py
@@ -105,7 +105,7 @@ class TrellisLEDs():
     def fill(self, on):
         fill = 0xff if on else 0x00
         for buff in range(len(self._parent._i2c_devices)):
-            for i in range(1, 16):
+            for i in range(1, 17):
                 self._parent._led_buffer[buff][i] = fill
         if self._parent._auto_show:
             self._parent.show()

--- a/adafruit_trellis.py
+++ b/adafruit_trellis.py
@@ -136,7 +136,7 @@ class Trellis():
         self._buttons = []
         for i2c_address in addresses:
             self._i2c_devices.append(i2c_device.I2CDevice(i2c, i2c_address))
-            self._led_buffer.append(bytearray(16))
+            self._led_buffer.append(bytearray(17))
             self._buttons.append([bytearray(6), bytearray(6)])
         self._num_leds = len(self._i2c_devices) * 16
         self._temp = bytearray(1)

--- a/examples/trellis_simpletest.py
+++ b/examples/trellis_simpletest.py
@@ -39,7 +39,7 @@ for i in range(16):
 
 # Turn off every LED, one at a time
 print('Turning off each LED, one at a time...')
-for i in range(15,-1,-1):
+for i in range(15,0,-1):
     trellis.led[i] = False
     time.sleep(.1)
 

--- a/examples/trellis_simpletest.py
+++ b/examples/trellis_simpletest.py
@@ -39,7 +39,7 @@ for i in range(16):
 
 # Turn off every LED, one at a time
 print('Turning off each LED, one at a time...')
-for i in range(15,0,-1):
+for i in range(15,-1,-1):
     trellis.led[i] = False
     time.sleep(.1)
 


### PR DESCRIPTION
As outlined in Issue #4, the library was failing on a Trinket. I reproduced the error on a Trinket, but it ran fine on a Feather M0 Express (which was the dev platform I used). The non-express boards don't have `array slicing` enabled, which was causing the issue.

All slicing has been removed. Tested on 2.2.4 firmware with a Trinket and a Feather M0 Express. Runs without any issues I could capture.

Thanks to @chris-schmitz for submitting the well documented issue. 