### PR TITLE
only apply mask to _led_buffer if < 256

### DIFF
--- a/adafruit_trellis.py
+++ b/adafruit_trellis.py
@@ -91,8 +91,7 @@ class TrellisLEDs():
         led = ledLUT[x % 16] >> 4
         mask = 1 << (ledLUT[x % 16] & 0x0f)
         if value:
-            if mask < 256:
-                self._parent._led_buffer[x // 16][(led * 2) + 1] |= mask
+            self._parent._led_buffer[x // 16][(led * 2) + 1] |= (mask & 0xff)
             self._parent._led_buffer[x // 16][(led * 2) + 2] |= mask >> 8
         elif not value:
             self._parent._led_buffer[x // 16][(led * 2) + 1] &= ~mask

--- a/adafruit_trellis.py
+++ b/adafruit_trellis.py
@@ -91,7 +91,8 @@ class TrellisLEDs():
         led = ledLUT[x % 16] >> 4
         mask = 1 << (ledLUT[x % 16] & 0x0f)
         if value:
-            self._parent._led_buffer[x // 16][(led * 2) + 1] |= mask
+            if mask < 256:
+                self._parent._led_buffer[x // 16][(led * 2) + 1] |= mask
             self._parent._led_buffer[x // 16][(led * 2) + 2] |= mask >> 8
         elif not value:
             self._parent._led_buffer[x // 16][(led * 2) + 1] &= ~mask


### PR DESCRIPTION
This works on CPython with a single Trellis board.  I _think_ it will work on CircuitPython, since the old behavior is effectively a no-op there.  I'll test shortly.  On CPython it was throwing a `ValueError`:

```
(.env) pi@raspberrypi:~/Adafruit_CircuitPython_Trellis $ python3 examples/trellis_simpletest.py 
Turning all LEDs on...
Turning all LEDs off...
Turning on each LED, one at a time...
Traceback (most recent call last):
  File "examples/trellis_simpletest.py", line 37, in <module>
    trellis.led[i] = True
  File "/home/pi/Adafruit_CircuitPython_Trellis/adafruit_trellis.py", line 94, in __setitem__
    self._parent._led_buffer[x // 16][(led * 2) + 1] |= mask
ValueError: byte must be in range(0, 256)
```

(The byte in question is definitely `mask`.)

I want to be clear that I don't understand this code, so I'm definitely not confident that this change is the Correct Thing.